### PR TITLE
Changed deployment target for OS X

### DIFF
--- a/TidyJSON.xcodeproj/project.pbxproj
+++ b/TidyJSON.xcodeproj/project.pbxproj
@@ -1391,7 +1391,7 @@
 				INFOPLIST_FILE = "Sources/Info-OSX.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.altdev.TidyJSON;
@@ -1446,7 +1446,7 @@
 				INFOPLIST_FILE = "Sources/Info-OSX.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.altdev.TidyJSON;
 				PRODUCT_NAME = TidyJSON;


### PR DESCRIPTION
Without it, it breaks for apps with deployment target lesser than El Capitan
